### PR TITLE
Fix running programs with spaces

### DIFF
--- a/winmin-scripts/winmin_run.py
+++ b/winmin-scripts/winmin_run.py
@@ -25,9 +25,9 @@ def startup(vm,program,arg,name,save):
     p.write("\r")
     time.sleep(0.5)
     if len(arg) >= 1:
-      p.write('startps "{}" "{}"\r'.format(program,arg))
+      p.write('startps \\"{}\\" \\"{}\\"\r'.format(program,arg))
     else:
-      p.write('startps "{}"\r'.format(program))
+      p.write('startps \\"{}\\"\r'.format(program))
     time.sleep(1)
     p.write("\r\r")
   print("commands EXECUTED!!!")
@@ -72,8 +72,8 @@ def main():
     file="\\\\{}\\winmin".format(ip)+file.replace("/","\\")
   else:
     file=""
-  
+
   startup(vm,program,file,name,save)
-  
+
 if __name__ == "__main__":
   main();


### PR DESCRIPTION
Currently, trying to run a program with a space in the name causes the following error: 

```cmd
C:\Windows\system32>startps "Visual Studio 2019"
ERROR: Invalid argument/option - 'Studio'.
Type "SCHTASKS /CREATE /?" for usage.
ERROR: The system cannot find the file specified.
ERROR: The system cannot find the file specified.
```
This is because the arguments arrive in `startps.bat` exactly as we pass them:

https://github.com/vlinkz/WinminWindows/blob/01b628547efa93aa666a9f811d6c1c38438e7604/startps.bat#L3

Which causing the following command to be executed for the example: `schtasks /create /sc once /tn test /tr "cmd.exe /C start \"\" /MAX "Visual Studio 2019" "Visual Studio 2019"" /ST 00:00` (note the quotes within quotes). Escaping the quotes we are passing seems to solve this problem.